### PR TITLE
Fix video playback issue by using ffmpeg for proper MP4 encoding and …

### DIFF
--- a/EyeView-frontend/src/pages/History.jsx
+++ b/EyeView-frontend/src/pages/History.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
-import ReactPlayer from "react-player";
 
 // --- SVG Icon Components ---
 // By using inline SVGs, we remove the need for the external 'react-icons' library.
@@ -125,26 +124,33 @@ const HistorySection = () => {
                 </p>
 
                 {clip.videoUrl ? (
-                  <div className="w-full h-auto rounded-md bg-black overflow-hidden aspect-video">
-                    <ReactPlayer
-                      url={clip.videoUrl}
-                      controls={true}
-                      width="100%"
-                      height="100%"
-                      onError={(e) => {
-                        console.error(
-                          `Error loading video: ${clip.videoUrl}`,
-                          e
-                        );
-                      }}
-                    />
-                  </div>
-                ) : (
-                  <div className="w-full h-48 bg-gray-700 rounded-md flex flex-col items-center justify-center text-gray-400">
-                    <WarningIcon className="text-2xl mb-2 text-red-400" />
-                    <p>Video unavailable</p>
-                  </div>
-                )}
+                    <div className="w-full h-auto rounded-md bg-black overflow-hidden aspect-video">
+                      <video
+                        key={clip.videoUrl}
+                        src={clip.videoUrl}
+                        controls
+                        className="w-full h-full"
+                        preload="metadata"
+                        onError={(e) => {
+                          console.error(
+                            `Error loading video: ${clip.videoUrl}`,
+                            e.target.error ? `Error code: ${e.target.error.code}, message: ${e.target.error.message}` : 'Unknown error'
+                          );
+                        }}
+                        onLoadedData={() => console.log(`Video loaded: ${clip.videoUrl}`)}
+                        onCanPlay={() => console.log(`Video can play: ${clip.videoUrl}`)}
+                        onCanPlayThrough={() => console.log(`Video can play through: ${clip.videoUrl}`)}
+                        onLoadStart={() => console.log(`Video load start: ${clip.videoUrl}`)}
+                        onStalled={() => console.log(`Video stalled: ${clip.videoUrl}`)}
+                        onSuspend={() => console.log(`Video suspended: ${clip.videoUrl}`)}
+                      />
+                    </div>
+                  ) : (
+                   <div className="w-full h-48 bg-gray-700 rounded-md flex flex-col items-center justify-center text-gray-400">
+                     <WarningIcon className="text-2xl mb-2 text-red-400" />
+                     <p>Video unavailable</p>
+                   </div>
+                 )}
 
                 <p className="text-xs text-gray-500 mt-2 truncate flex items-center gap-2">
                   <VideoIcon className="text-gray-400" />


### PR DESCRIPTION
## Fix Video Playback Issue in History Page

### Problem
The video player in the History page was failing to play video clips in web browsers, showing a "MEDIA_ERR_SRC_NOT_SUPPORTED" error. Videos played correctly in external/internal video players, indicating an encoding compatibility issue with HTML5 video.

### Root Cause
Videos were being saved using OpenCV's VideoWriter with codecs that produced MP4 containers but with encodings not supported by web browsers. The VideoWriter initialization was also inconsistent, leading to corrupted or unplayable files.

### Solution
- **Backend Changes**: Replaced OpenCV VideoWriter with ffmpeg for proper H.264 MP4 encoding. Videos are now saved by extracting frames as images and using ffmpeg to create web-compatible MP4 files.
- **Frontend Changes**: Added a `key` prop to the video element to ensure proper remounting when switching clips, and enhanced error logging for better debugging.
- **Concurrency Fix**: Made temporary frame directories unique per video to prevent conflicts during simultaneous clip saving.

### Files Changed
- `Backend/eye-view.py`: Updated `save_clip` function to use ffmpeg subprocess
- `EyeView-frontend/src/pages/History.jsx`: Added video element improvements and logging

### Requirements
- ffmpeg must be installed (static build recommended from https://github.com/BtbN/FFmpeg-Builds/releases)
- Path configured in code: `C:\ffmpeg\bin\ffmpeg.exe` (adjust if different)

### Testing
- Trigger new alerts to create fresh clips
- Verify videos play in browser History page
- Old corrupted MP4 files should be manually removed from `Backend/static/history_clips/`

Closes # [issue number if applicable]
